### PR TITLE
Add yaml description for spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+.idea
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
     "./okapi-operation-macro",
-    "./okapi-operation"
+    "./okapi-operation",
+    "./okapi-examples"
 ]

--- a/okapi-examples/Cargo.toml
+++ b/okapi-examples/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "okapi-examples"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+axum = { version = "0.6", features = ["headers"] }
+tokio = { version = "1.28.0", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+okapi-operation = { path = "../okapi-operation" }
+okapi-operation-macro = { path = "../okapi-operation-macro" }

--- a/okapi-examples/src/main.rs
+++ b/okapi-examples/src/main.rs
@@ -1,0 +1,51 @@
+use axum::{extract::Query, Json};
+use okapi_operation::{axum_integration::*, *};
+use serde::Deserialize;
+
+#[derive(Deserialize, JsonSchema)]
+struct Request {
+    /// Echo data
+    data: String,
+}
+
+#[openapi(
+    summary = "Echo using GET request",
+    operation_id = "echo_get",
+    tags = "echo",
+    parameters(
+        query(name = "echo-data", required = true, schema = "std::string::String",),
+        header(name = "x-request-id", schema = "std::string::String",),
+        header(name = "Accept", schema = "std::string::String")
+    )
+)]
+async fn echo_get(query: Query<Request>) -> Json<String> {
+    Json(query.0.data)
+}
+
+#[openapi(
+    summary = "Echo using POST request",
+    operation_id = "echo_post",
+    tags = "echo"
+)]
+async fn echo_post(
+    #[request_body(description = "Echo data", required = true)] body: Json<Request>,
+) -> Json<String> {
+    Json(body.0.data)
+}
+
+#[tokio::main]
+async fn main() {
+    // Here you can also add security schemes, other operations, modify internal OpenApi object.
+    let oas_builder = OpenApiBuilder::new("Demo", "1.0.0");
+
+    let app = Router::new()
+        .route("/echo/get", get(openapi_handler!(echo_get)))
+        .route("/echo/post", post(openapi_handler!(echo_post)))
+        .route_openapi_specification("/openapi", oas_builder)
+        .expect("no problem");
+
+    axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
+        .serve(app.into_make_service())
+        .await
+        .unwrap()
+}

--- a/okapi-operation/Cargo.toml
+++ b/okapi-operation/Cargo.toml
@@ -19,6 +19,7 @@ okapi = { version = "0.7.0-rc.1", features = ["preserve_order"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.8"
+bytes = "1.4.0"
 
 axum = { version = "0.6", optional = true }
 tower = { version = "0.4", default-features = false, optional = true }

--- a/okapi-operation/src/axum_integration/axumyaml.rs
+++ b/okapi-operation/src/axum_integration/axumyaml.rs
@@ -1,0 +1,34 @@
+use axum::response::{IntoResponse, Response};
+use bytes::{BufMut, BytesMut};
+use http::{header, HeaderValue, StatusCode};
+use serde::Serialize;
+
+pub struct AxumYaml<T>(pub T);
+
+impl<T> IntoResponse for AxumYaml<T>
+where
+    T: Serialize,
+{
+    fn into_response(self) -> Response {
+        let mut buf = BytesMut::with_capacity(128).writer();
+        match serde_yaml::to_writer(&mut buf, &self.0) {
+            Ok(()) => (
+                [(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static("text/x-yaml"),
+                )],
+                buf.into_inner().freeze(),
+            )
+                .into_response(),
+            Err(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                [(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static("text/plain; charset=utf-8"),
+                )],
+                err.to_string(),
+            )
+                .into_response(),
+        }
+    }
+}


### PR DESCRIPTION
This MR adds ability for the user to request spec in YAML format. This can be achieved by providing Accept header with yaml value. Here's the returned response for the example provided in the project
```
openapi: 3.0.0
info:
  title: Demo
  version: 1.0.0
paths:
  /echo/get:
    get:
      tags:
        - echo
      summary: Echo using GET request
      operationId: echo_get
      parameters:
        - name: x-request-id
          in: header
          schema:
            type: string
        - name: Accept
          in: header
          schema:
            type: string
        - name: echo-data
          in: query
          required: true
          schema:
            type: string
      responses:
        "200":
          description: ""
          content:
            application/json:
              schema:
                type: string
  /echo/post:
    post:
      tags:
        - echo
      summary: Echo using POST request
      operationId: echo_post
      requestBody:
        description: Echo data
        content:
          application/json:
            schema:
              $ref: "#/components/schemas/Request"
        required: true
      responses:
        "200":
          description: ""
          content:
            application/json:
              schema:
                type: string
  /openapi:
    get:
      tags:
        - openapi
      summary: OpenAPI specification
      externalDocs:
        url: "https://swagger.io/specification/"
      operationId: openapi_spec
      responses:
        "200":
          description: ""
          content:
            application/json:
              schema:
                type: object
                additionalProperties:
                  type: string
components:
  schemas:
    Request:
      type: object
      required:
        - data
      properties:
        data:
          description: Echo data
          type: string
```