### PR TITLE
Fixing the okapi extension router.

### DIFF
--- a/okapi-operation/CHANGELOG.md
+++ b/okapi-operation/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in the changelog of the r
 This project follows the [Semantic Versioning standard](https://semver.org/).
 
 
+## [0.2.2] - 2023-08-30
+### Added
+ - Updating the router so that it supports middleware correctly. All that was
+done was the extra generic arguments were removed so they don't have to be
+listed anymore. This is to allow integration with the newest versions of axum
+0.6.x which don't have this generic argument any longer.
+
 ## [0.2.1] - 2023-05-09
 ### Added
  - Serving spec in different formats in `axum` integration using `Accept` header (JSON supported by default, YAML behind `yaml` feature).

--- a/okapi-operation/Cargo.toml
+++ b/okapi-operation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "okapi-operation"
 description = "Procedural macro for generating OpenAPI operation specification (using okapi)"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Andrey Kononov flowneee3@gmail.com"]
 edition = "2021"
 license = "MIT"

--- a/okapi-operation/src/axum_integration/router.rs
+++ b/okapi-operation/src/axum_integration/router.rs
@@ -207,7 +207,7 @@ where
     /// Apply a [`tower::Layer`] to the router.
     ///
     /// For details see [`axum::Router::layer`].
-    pub fn layer<L, NewReqBody, NewResBody>(self, layer: L) -> Router<S, NewReqBody>
+    pub fn layer<L, NewReqBody>(self, layer: L) -> Router<S, NewReqBody>
     where
         L: Layer<Route<B>> + Clone + Send + 'static,
         L::Service: Service<Request<NewReqBody>> + Clone + Send + 'static,
@@ -225,7 +225,7 @@ where
     /// Apply a [`tower::Layer`] to the router that will only run if the request matches a route.
     ///
     /// For details see [`axum::Router::route_layer`].
-    pub fn route_layer<L, NewResBody>(self, layer: L) -> Self
+    pub fn route_layer<L>(self, layer: L) -> Self
     where
         L: Layer<Route<B>> + Clone + Send + 'static,
         L::Service: Service<Request<B>> + Clone + Send + 'static,


### PR DESCRIPTION
I ran into an issue with the `axum_extension`. I was unable to easily use middleware without having to specify the body type associated with the middleware. The current version of axum allows you to use a generic parameter for the body type, so I removed the parameter from both `route_layer` and `layer` functions. Now if this causes issues we can make this optionally enabled/disabled for backward compatibility. 