### PR TITLE
Replace hashmap with indexmap

### DIFF
--- a/okapi-operation/CHANGELOG.md
+++ b/okapi-operation/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in the changelog of the respective crates.
 This project follows the [Semantic Versioning standard](https://semver.org/).
 
+## [Unreleased]
+### Fixed
+ - (breaking) Switched to using `indexmap` in place of `hashmap` to make produced specs deterministic.
 
 ## [0.3.0-rc1] - 2023-12-03
 ### Notable changes

--- a/okapi-operation/Cargo.toml
+++ b/okapi-operation/Cargo.toml
@@ -24,6 +24,7 @@ axum = { version = "0.7", optional = true }
 tower = { version = "0.4", default-features = false, optional = true }
 paste = { version = "1", optional = true }
 serde_yaml = { version = "0.8", optional = true }
+indexmap = "2.2.6"
 
 [dev-dependencies]
 axum = "0.7"

--- a/okapi-operation/src/builder.rs
+++ b/okapi-operation/src/builder.rs
@@ -265,3 +265,34 @@ fn try_add_path(
     }
     Ok(())
 }
+
+/// Ensures that a builder always generates the same file every time, by not relying on
+/// internal data structures that may contain random ordering, e.g. [`std::collections::HashMap`].
+#[test]
+fn ensure_builder_deterministic() {
+    use okapi::openapi3::Operation;
+
+    let mut built_specs = Vec::new();
+
+    // generate 100 specs
+    for _ in 0..100 {
+        let mut builder = OpenApiBuilder::new("title", "version");
+        for i in 0..2 {
+            builder.operation(
+                format!("/path/{}", i),
+                Method::GET,
+                |_| Ok(Operation::default()),
+            );
+        }
+
+        let spec = builder.build()
+            .map(|x| format!("{:?}", x))
+            .expect("Failed to build spec");
+        built_specs.push(spec);
+    }
+
+    // ensure all specs are the same
+    for i in 1..built_specs.len() {
+        assert_eq!(built_specs[i - 1], built_specs[i]);
+    }
+}

--- a/okapi-operation/src/builder.rs
+++ b/okapi-operation/src/builder.rs
@@ -1,7 +1,6 @@
-use std::collections::HashMap;
-
 use anyhow::{bail, Context};
 use http::Method;
+use indexmap::IndexMap;
 use okapi::openapi3::{
     Contact, ExternalDocs, License, OpenApi, SecurityRequirement, SecurityScheme, Server, Tag,
 };
@@ -13,7 +12,7 @@ use crate::{components::Components, OperationGenerator};
 pub struct OpenApiBuilder {
     spec: OpenApi,
     components: Components,
-    operations: HashMap<(String, Method), OperationGenerator>,
+    operations: IndexMap<(String, Method), OperationGenerator>,
 }
 
 impl Default for OpenApiBuilder {
@@ -25,7 +24,7 @@ impl Default for OpenApiBuilder {
         Self {
             spec,
             components: Components::new(Default::default()),
-            operations: HashMap::new(),
+            operations: IndexMap::new(),
         }
     }
 }


### PR DESCRIPTION
In `okapi-operation` 0.3.0-rc1 there [is a loop](https://docs.rs/okapi-operation/0.3.0-rc1/src/okapi_operation/builder.rs.html#150) over a `std::collections::HashMap` which means it will visit the keys in an ["arbitrary order"](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.iter). 

This is because the seeder in the default HashMap implementation is seeded with a [random number generator](https://doc.rust-lang.org/std/collections/hash_map/struct.RandomState.html) to prevent HashDoS attacks.

In our use case we commit the results of [`.build()`](https://docs.rs/okapi-operation/0.3.0-rc1/okapi_operation/struct.OpenApiBuilder.html#method.build)ing to our version tracking system, which changes most commits as the generation function is not stable. Note that this would also cause problems for users who run ANY automated tests against the results of the [`.build()`](https://docs.rs/okapi-operation/0.3.0-rc1/okapi_operation/struct.OpenApiBuilder.html#method.build) function, e.g. snapshots.

Okapi's [Map type](https://docs.rs/okapi/latest/okapi/type.Map.html) uses an [IndexMap](https://docs.rs/schemars/0.8.16/schemars/type.Map.html) to preserve insertion order when the `preserve_order` flag is enabled (as in this repo). I have used the same approach, and added a test case to discourage regressions.