### PR TITLE
Add content field support for path, query, header, and cookie parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ fn main() {
 }
 ```
 
+## Parameters
+
+Parameters (`path`, `query`, `header`, `cookie`) support two mutually exclusive ways to describe the parameter value:
+
+- `schema = "Type"` — describes the parameter inline using a JSON Schema derived from the given type (default, as in the example above);
+- `content = "media/type", schema = "Type"` — describes the parameter via a media type map (`ParameterValue::Content`), useful when the parameter encoding requires a specific media type (e.g. `application/json`).
+
+```rust,no_run
+#[openapi(
+    parameters(
+        // inline schema
+        query(name = "id", schema = "u64"),
+        // content-based
+        query(name = "filter", content = "application/json", schema = "MyFilter"),
+        path(name = "slug", content = "text/plain", schema = "String"),
+    )
+)]
+async fn handler() { ... }
+```
+
 ## Features
 
 - `macro`: enables re-import of `#[openapi]` macro (enabled by default);

--- a/okapi-examples/src/main.rs
+++ b/okapi-examples/src/main.rs
@@ -8,6 +8,14 @@ struct Request {
     data: String,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+struct SearchFilter {
+    /// Minimum value
+    min: Option<i32>,
+    /// Maximum value
+    max: Option<i32>,
+}
+
 #[openapi(
     summary = "Echo using GET request",
     tags = "echo",
@@ -38,6 +46,25 @@ async fn echo_put(body: Json<Request>) -> Json<String> {
     Json(body.0.data)
 }
 
+// Demonstrates content-based parameter: the `filter` query parameter is described
+// as application/json rather than a plain schema, which is useful for complex objects
+// that are JSON-encoded in the query string.
+#[openapi(
+    summary = "Search with JSON-encoded filter",
+    tags = "search",
+    parameters(
+        query(
+            name = "filter",
+            required = false,
+            content = "application/json",
+            schema = "SearchFilter"
+        ),
+    )
+)]
+async fn search(query: Query<SearchFilter>) -> Json<String> {
+    Json(format!("min={:?} max={:?}", query.0.min, query.0.max))
+}
+
 #[tokio::main]
 async fn main() {
     let app = Router::new()
@@ -45,6 +72,7 @@ async fn main() {
             "/echo",
             get(oh!(echo_get)).post(oh!(echo_post)).put(oh!(echo_put)),
         )
+        .route("/search", get(oh!(search)))
         .finish_openapi("/openapi", "Demo", "1.0.0")
         .expect("no problem");
 

--- a/okapi-examples/src/main.rs
+++ b/okapi-examples/src/main.rs
@@ -52,14 +52,12 @@ async fn echo_put(body: Json<Request>) -> Json<String> {
 #[openapi(
     summary = "Search with JSON-encoded filter",
     tags = "search",
-    parameters(
-        query(
-            name = "filter",
-            required = false,
-            content = "application/json",
-            schema = "SearchFilter"
-        ),
-    )
+    parameters(query(
+        name = "filter",
+        required = false,
+        content = "application/json",
+        schema = "SearchFilter"
+    ),)
 )]
 async fn search(query: Query<SearchFilter>) -> Json<String> {
     Json(format!("min={:?} max={:?}", query.0.min, query.0.max))

--- a/okapi-operation-macro/CHANGELOG.md
+++ b/okapi-operation-macro/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in the changelog of the respective crates.
 This project follows the [Semantic Versioning standard](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Support `content` field for `path`, `query`, `header`, and `cookie` parameters — allows specifying a parameter value via `ParameterValue::Content` (a media type map) instead of `ParameterValue::Schema`.
+
 ## [0.3.0] - 2025-06-15
 
 Release `0.3.0` version.

--- a/okapi-operation-macro/src/operation/cookie.rs
+++ b/okapi-operation-macro/src/operation/cookie.rs
@@ -22,7 +22,8 @@ pub(super) struct Cookie {
     #[darling(default)]
     allow_empty_value: bool,
     schema: Path,
-    // TODO: support content as well
+    #[darling(default)]
+    content: Option<String>,
 }
 
 impl ToTokens for Cookie {
@@ -31,11 +32,39 @@ impl ToTokens for Cookie {
         let description = quote_option(&self.description);
         let required = &self.required;
         let deprecated = &self.deprecated;
-        let style = ParameterStyle::Form;
-        let explode = quote_option(&self.explode);
         let allow_empty_values = &self.allow_empty_value;
-        let allow_reserved = false;
         let ty = &self.schema;
+        let value = if let Some(media_type) = &self.content {
+            quote! {
+                okapi::openapi3::ParameterValue::Content {
+                    content: {
+                        let mut __map = okapi::Map::new();
+                        __map.insert(
+                            #media_type.to_string(),
+                            okapi::openapi3::MediaType {
+                                schema: Some(components.schema_for::<#ty>()),
+                                ..Default::default()
+                            },
+                        );
+                        __map
+                    },
+                }
+            }
+        } else {
+            let style = ParameterStyle::Form;
+            let explode = quote_option(&self.explode);
+            let allow_reserved = false;
+            quote! {
+                okapi::openapi3::ParameterValue::Schema {
+                    style: #style,
+                    explode: #explode,
+                    allow_reserved: #allow_reserved,
+                    schema: components.schema_for::<#ty>(),
+                    example: Default::default(),
+                    examples: Default::default(),
+                }
+            }
+        };
         tokens.extend(quote! {
             okapi::openapi3::Parameter {
                 name: #name.into(),
@@ -44,16 +73,7 @@ impl ToTokens for Cookie {
                 required: #required,
                 deprecated: #deprecated,
                 allow_empty_value: #allow_empty_values,
-                value: {
-                    okapi::openapi3::ParameterValue::Schema {
-                        style: #style,
-                        explode: #explode,
-                        allow_reserved: #allow_reserved,
-                        schema: components.schema_for::<#ty>(),
-                        example: Default::default(),
-                        examples: Default::default(),
-                    }
-                },
+                value: { #value },
                 extensions: Default::default(),
             }
         });

--- a/okapi-operation-macro/src/operation/header.rs
+++ b/okapi-operation-macro/src/operation/header.rs
@@ -58,11 +58,11 @@ impl Header {
         }
     }
 
-    pub(super) fn for_parameter(&self) -> ParameterHeader {
+    pub(super) fn for_parameter(&self) -> ParameterHeader<'_> {
         ParameterHeader(self)
     }
 
-    pub(super) fn for_response(&self) -> ResponseHeader {
+    pub(super) fn for_response(&self) -> ResponseHeader<'_> {
         ResponseHeader(self)
     }
 }

--- a/okapi-operation-macro/src/operation/header.rs
+++ b/okapi-operation-macro/src/operation/header.rs
@@ -20,21 +20,40 @@ pub(super) struct Header {
     #[darling(default)]
     style: Option<ParameterStyle>,
     schema: Path,
-    // TODO: support content as well
+    #[darling(default)]
+    content: Option<String>,
 }
 
 impl Header {
-    fn schema(&self) -> TokenStream {
-        let style = quote_option(&self.style);
+    fn value(&self) -> TokenStream {
         let ty = &self.schema;
-        quote! {
-            okapi::openapi3::ParameterValue::Schema {
-                style: #style,
-                explode: None,
-                allow_reserved: false,
-                schema: components.schema_for::<#ty>(),
-                example: Default::default(),
-                examples: Default::default(),
+        if let Some(media_type) = &self.content {
+            quote! {
+                okapi::openapi3::ParameterValue::Content {
+                    content: {
+                        let mut __map = okapi::Map::new();
+                        __map.insert(
+                            #media_type.to_string(),
+                            okapi::openapi3::MediaType {
+                                schema: Some(components.schema_for::<#ty>()),
+                                ..Default::default()
+                            },
+                        );
+                        __map
+                    },
+                }
+            }
+        } else {
+            let style = quote_option(&self.style);
+            quote! {
+                okapi::openapi3::ParameterValue::Schema {
+                    style: #style,
+                    explode: None,
+                    allow_reserved: false,
+                    schema: components.schema_for::<#ty>(),
+                    example: Default::default(),
+                    examples: Default::default(),
+                }
             }
         }
     }
@@ -57,7 +76,7 @@ impl ToTokens for ParameterHeader<'_> {
         let description = quote_option(&self.0.description);
         let required = &self.0.required;
         let deprecated = &self.0.deprecated;
-        let schema = self.0.schema();
+        let value = self.0.value();
         let new_tokens = quote! {
             okapi::openapi3::Parameter {
                 name: #name.into(),
@@ -66,7 +85,7 @@ impl ToTokens for ParameterHeader<'_> {
                 required: #required,
                 deprecated: #deprecated,
                 allow_empty_value: false,
-                value: #schema,
+                value: #value,
                 extensions: Default::default(),
             }
         };
@@ -82,14 +101,14 @@ impl ToTokens for ResponseHeader<'_> {
         let description = quote_option(&self.0.description);
         let required = &self.0.required;
         let deprecated = &self.0.deprecated;
-        let schema = self.0.schema();
+        let value = self.0.value();
         tokens.extend(quote! {
             okapi::openapi3::Header {
                 description: #description,
                 required: #required,
                 deprecated: #deprecated,
                 allow_empty_value: false,
-                value: #schema,
+                value: #value,
                 extensions: Default::default(),
             }
         });

--- a/okapi-operation-macro/src/operation/path.rs
+++ b/okapi-operation-macro/src/operation/path.rs
@@ -17,7 +17,8 @@ pub(super) struct Path {
     #[darling(default)]
     style: Option<ParameterStyle>,
     schema: syn::Path,
-    // TODO: support content as well
+    #[darling(default)]
+    content: Option<String>,
 }
 
 impl ToTokens for Path {
@@ -25,8 +26,36 @@ impl ToTokens for Path {
         let name = &self.name;
         let description = quote_option(&self.description);
         let deprecated = &self.deprecated;
-        let style = quote_option(&self.style);
         let ty = &self.schema;
+        let value = if let Some(media_type) = &self.content {
+            quote! {
+                okapi::openapi3::ParameterValue::Content {
+                    content: {
+                        let mut __map = okapi::Map::new();
+                        __map.insert(
+                            #media_type.to_string(),
+                            okapi::openapi3::MediaType {
+                                schema: Some(components.schema_for::<#ty>()),
+                                ..Default::default()
+                            },
+                        );
+                        __map
+                    },
+                }
+            }
+        } else {
+            let style = quote_option(&self.style);
+            quote! {
+                okapi::openapi3::ParameterValue::Schema {
+                    style: #style,
+                    explode: None,
+                    allow_reserved: false,
+                    schema: components.schema_for::<#ty>(),
+                    example: Default::default(),
+                    examples: Default::default(),
+                }
+            }
+        };
         tokens.extend(quote! {
             okapi::openapi3::Parameter {
                 name: #name.into(),
@@ -35,16 +64,7 @@ impl ToTokens for Path {
                 required: true,
                 deprecated: #deprecated,
                 allow_empty_value: false,
-                value: {
-                    okapi::openapi3::ParameterValue::Schema {
-                        style: #style,
-                        explode: None,
-                        allow_reserved: false,
-                        schema: components.schema_for::<#ty>(),
-                        example: Default::default(),
-                        examples: Default::default(),
-                    }
-                },
+                value: { #value },
                 extensions: Default::default(),
             }
         });

--- a/okapi-operation-macro/src/operation/query.rs
+++ b/okapi-operation-macro/src/operation/query.rs
@@ -26,7 +26,8 @@ pub(super) struct Query {
     #[darling(default)]
     allow_reserved: bool,
     schema: Path,
-    // TODO: support content as well
+    #[darling(default)]
+    content: Option<String>,
 }
 
 impl ToTokens for Query {
@@ -35,11 +36,39 @@ impl ToTokens for Query {
         let description = quote_option(&self.description);
         let required = &self.required;
         let deprecated = &self.deprecated;
-        let style = quote_option(&self.style);
-        let explode = quote_option(&self.explode);
         let allow_empty_values = &self.allow_empty_value;
-        let allow_reserved = &self.allow_reserved;
         let ty = &self.schema;
+        let value = if let Some(media_type) = &self.content {
+            quote! {
+                okapi::openapi3::ParameterValue::Content {
+                    content: {
+                        let mut __map = okapi::Map::new();
+                        __map.insert(
+                            #media_type.to_string(),
+                            okapi::openapi3::MediaType {
+                                schema: Some(components.schema_for::<#ty>()),
+                                ..Default::default()
+                            },
+                        );
+                        __map
+                    },
+                }
+            }
+        } else {
+            let style = quote_option(&self.style);
+            let explode = quote_option(&self.explode);
+            let allow_reserved = &self.allow_reserved;
+            quote! {
+                okapi::openapi3::ParameterValue::Schema {
+                    style: #style,
+                    explode: #explode,
+                    allow_reserved: #allow_reserved,
+                    schema: components.schema_for::<#ty>(),
+                    example: Default::default(),
+                    examples: Default::default(),
+                }
+            }
+        };
         tokens.extend(quote! {
             okapi::openapi3::Parameter {
                 name: #name.into(),
@@ -48,16 +77,7 @@ impl ToTokens for Query {
                 required: #required,
                 deprecated: #deprecated,
                 allow_empty_value: #allow_empty_values,
-                value: {
-                    okapi::openapi3::ParameterValue::Schema {
-                        style: #style,
-                        explode: #explode,
-                        allow_reserved: #allow_reserved,
-                        schema: components.schema_for::<#ty>(),
-                        example: Default::default(),
-                        examples: Default::default(),
-                    }
-                },
+                value: { #value },
                 extensions: Default::default(),
             }
         });

--- a/okapi-operation/tests/axum_integration.rs
+++ b/okapi-operation/tests/axum_integration.rs
@@ -69,6 +69,90 @@ mod openapi {
 }
 
 #[cfg(feature = "axum")]
+mod parameters {
+    use okapi::openapi3::{ParameterValue, RefOr};
+    use okapi_operation::{axum_integration::{Router, get}, oh, openapi};
+
+    fn get_parameter(name: &str) -> okapi::openapi3::Parameter {
+        #[openapi(
+            parameters(
+                query(name = "schema-param", required = true, schema = "String"),
+                query(name = "content-param", required = false, content = "application/json", schema = "String"),
+                path(name = "path-param", content = "text/plain", schema = "u32"),
+                header(name = "x-custom", schema = "String"),
+                header(name = "x-custom-content", content = "application/json", schema = "String"),
+            )
+        )]
+        async fn handle() {}
+
+        let schema = Router::<()>::new()
+            .route("/", get(oh!(handle)))
+            .generate_openapi_builder()
+            .build()
+            .expect("schema generation shouldn't fail");
+
+        let operation = schema.paths["/"].clone().get.expect("GET / should be present");
+        operation
+            .parameters
+            .into_iter()
+            .find_map(|p| match p {
+                RefOr::Object(p) if p.name == name => Some(p),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("parameter '{}' not found", name))
+    }
+
+    #[test]
+    fn query_schema_value() {
+        let param = get_parameter("schema-param");
+        assert!(
+            matches!(param.value, ParameterValue::Schema { .. }),
+            "query with schema= should produce ParameterValue::Schema"
+        );
+    }
+
+    #[test]
+    fn query_content_value() {
+        let param = get_parameter("content-param");
+        let ParameterValue::Content { content } = param.value else {
+            panic!("query with content= should produce ParameterValue::Content");
+        };
+        assert!(
+            content.contains_key("application/json"),
+            "content map should contain 'application/json'"
+        );
+        assert!(
+            content["application/json"].schema.is_some(),
+            "MediaType schema should be present"
+        );
+    }
+
+    #[test]
+    fn path_content_value() {
+        let param = get_parameter("path-param");
+        let ParameterValue::Content { content } = param.value else {
+            panic!("path with content= should produce ParameterValue::Content");
+        };
+        assert!(content.contains_key("text/plain"));
+    }
+
+    #[test]
+    fn header_schema_value() {
+        let param = get_parameter("x-custom");
+        assert!(matches!(param.value, ParameterValue::Schema { .. }));
+    }
+
+    #[test]
+    fn header_content_value() {
+        let param = get_parameter("x-custom-content");
+        let ParameterValue::Content { content } = param.value else {
+            panic!("header with content= should produce ParameterValue::Content");
+        };
+        assert!(content.contains_key("application/json"));
+    }
+}
+
+#[cfg(feature = "axum")]
 #[allow(deprecated)]
 mod openapi_handler {
     use axum::body::Body;

--- a/okapi-operation/tests/axum_integration.rs
+++ b/okapi-operation/tests/axum_integration.rs
@@ -71,18 +71,28 @@ mod openapi {
 #[cfg(feature = "axum")]
 mod parameters {
     use okapi::openapi3::{ParameterValue, RefOr};
-    use okapi_operation::{axum_integration::{Router, get}, oh, openapi};
+    use okapi_operation::{
+        axum_integration::{Router, get},
+        oh, openapi,
+    };
 
     fn get_parameter(name: &str) -> okapi::openapi3::Parameter {
-        #[openapi(
-            parameters(
-                query(name = "schema-param", required = true, schema = "String"),
-                query(name = "content-param", required = false, content = "application/json", schema = "String"),
-                path(name = "path-param", content = "text/plain", schema = "u32"),
-                header(name = "x-custom", schema = "String"),
-                header(name = "x-custom-content", content = "application/json", schema = "String"),
-            )
-        )]
+        #[openapi(parameters(
+            query(name = "schema-param", required = true, schema = "String"),
+            query(
+                name = "content-param",
+                required = false,
+                content = "application/json",
+                schema = "String"
+            ),
+            path(name = "path-param", content = "text/plain", schema = "u32"),
+            header(name = "x-custom", schema = "String"),
+            header(
+                name = "x-custom-content",
+                content = "application/json",
+                schema = "String"
+            ),
+        ))]
         async fn handle() {}
 
         let schema = Router::<()>::new()
@@ -91,7 +101,10 @@ mod parameters {
             .build()
             .expect("schema generation shouldn't fail");
 
-        let operation = schema.paths["/"].clone().get.expect("GET / should be present");
+        let operation = schema.paths["/"]
+            .clone()
+            .get
+            .expect("GET / should be present");
         operation
             .parameters
             .into_iter()


### PR DESCRIPTION
Parameters now accept an optional `content` field (media type string, e.g. "application/json"). When set, the macro emits `ParameterValue::Content` with a single-entry media type map instead of `ParameterValue::Schema`, in compliance with the OpenAPI 3.0 spec.

Backward-compatible: existing `schema`-only usage is unchanged.